### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions-all:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering three ecosystems: `npm` (root), `cargo` (`/src-tauri`), and `github-actions` (`.github/workflows`).
- Weekly schedule, max 5 open PRs per ecosystem.
- Minor/patch updates grouped into a single PR per ecosystem to reduce noise. Major bumps land as separate PRs since they often need code changes.

## Why
Part of repo hygiene pass. Dependabot security updates are already enabled — this adds proactive version updates so deps don't drift.