### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Scriptty, please report it
+privately so it can be fixed before public disclosure.
+
+**Preferred:** use GitHub's [private vulnerability reporting](https://github.com/stultus/scriptty/security/advisories/new).
+
+**Alternative:** email the maintainer at hrishi.kb@gmail.com with a
+description, reproduction steps, and impact assessment.
+
+You should expect an initial response within 7 days. Please do not file
+public issues for security problems.
+
+## Scope
+
+In scope:
+- The Scriptty desktop application (Tauri shell, SvelteKit UI, Typst
+  rendering pipeline)
+- The release / build workflows under `.github/workflows`
+
+Out of scope:
+- Third-party dependencies (report upstream and notify us)
+- Content within user-authored screenplays


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` with private vulnerability reporting policy.
- Points reporters to GitHub's Private Vulnerability Reporting (now enabled) and a fallback email.
- Defines scope (app + release workflows) and out-of-scope items.

## Why
Repo hygiene: gives security researchers a clear, private channel and surfaces a "Security" tab in the GitHub repo UI.