### PR TITLE
ci(release): pin tauri-action to commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,9 @@ jobs:
         run: npm ci
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v1
+        # Pinned to a commit SHA so a moved/compromised upstream tag can't inject
+        # code into our signed release builds (#213). Dependabot bumps the SHA.
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # macOS code signing — signs the app with a Developer ID certificate


### PR DESCRIPTION
Closes #213.

`release.yml` referenced `tauri-apps/tauri-action` by the mutable `v1` tag (the issue was filed against `@v0`; #244 has since bumped it to `@v1` — same problem, different tag). A moved or compromised upstream tag could inject code into our release builds, which get signed with the Apple Developer ID and notarized.

Now pinned to the immutable commit `1deb371b0cd8bd54025b384f1cd735e725c4060f` (= `v1.0.0`, the current target of `v1`). Dependabot's `github-actions` config will open PRs advancing the SHA when new versions land.

Not touched here: `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` are also third-party mutable refs in the release path — noted in #213's thread for a follow-up decision, since pinning `rust-toolchain` by SHA changes how the toolchain is selected.