### PR TITLE
ci: scope release token permissions + add job timeouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v*'
 
+# Least-privilege token: tauri-action only needs to create the draft
+# release and upload installer assets. Nothing here writes code,
+# issues, or packages (#211).
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:
@@ -25,6 +31,9 @@ jobs:
             label: Linux-x64
 
     runs-on: ${{ matrix.platform }}
+    # A hung build (stuck notarization, frozen download) would otherwise
+    # run for GitHub's 6-hour default — per matrix job (#211).
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   update-downloads:
     runs-on: ubuntu-latest
+    # Small job — regenerates one JSON file and pushes (#211).
+    timeout-minutes: 15
     permissions:
       contents: write
 


### PR DESCRIPTION
Closes #211.

- `release.yml`: workflow-level `permissions: contents: write` (the only repo write is tauri-action creating the draft release + uploading assets — verified each step) and `timeout-minutes: 60` per matrix job so a hung build can't burn the 6-hour default across 4 platforms.
- `update-downloads.yml`: `timeout-minutes: 15` (permissions were already scoped).