### PR TITLE
ci: add CodeQL scanning for TypeScript/Svelte and Rust

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly sweep in addition to per-push scans, so newly added CodeQL
+    # queries also get run against unchanged code.
+    - cron: '23 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      # Required to upload scan results to the repo's Security tab.
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Covers .ts and the <script> blocks of .svelte files.
+          - language: javascript-typescript
+            build-mode: none
+          # src-tauri backend. build-mode none = no compilation needed,
+          # so the WebKit/GTK system deps of a full Tauri build aren't
+          # required on the runner.
+          - language: rust
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
Closes #210.

Adds `.github/workflows/codeql.yml`:

- **Languages:** `javascript-typescript` (.ts + .svelte script blocks) and `rust` (src-tauri), both with `build-mode: none` — no compilation, so no WebKit/GTK deps needed on the runner.
- **Triggers:** push to main, PRs to main, weekly Monday sweep.
- **Queries:** `security-and-quality` pack.
- **Permissions:** workflow-level `contents: read`; the job additionally gets `security-events: write` to upload findings to the Security tab.

Findings will appear under Security → Code scanning and as PR annotations. If the Rust extractor turns out not to cope with the workspace layout, we can drop that matrix entry without losing the JS/TS coverage.